### PR TITLE
mv sops tfstate

### DIFF
--- a/infra/credential/sops/provider.tf
+++ b/infra/credential/sops/provider.tf
@@ -13,7 +13,7 @@ terraform {
   required_version = "1.9.5"
   backend "s3" {
     bucket = "dev-react-vite-sample-tfstate"
-    key    = "kms/terraform.tfstate"
+    key    = "credential/sops/terraform.tfstate"
   }
   required_providers {
     aws = {


### PR DESCRIPTION
### 実装内容

sopsのtfstateの管理先に誤りがあったため修正
- before: kms/terraform.tfstate
- after : credential/sops/terraform.tfstate

### 実行ログ

ディレクトリの変更のみなので、aws cliでtfstateを移動し、再度make initで遷移後のtfstateを参照

```bash
aws --profile miyabiii0310 \
  s3 cp s3://dev-react-vite-sample-tfstate/kms/terraform.tfstate ./terraform.tfstate.backup && \
  ls -lh ./terraform.tfstate.backup
```

```bash
aws --profile miyabiii0310 \
  s3 mv s3://dev-react-vite-sample-tfstate/kms/terraform.tfstate s3://dev-react-vite-sample-tfstate/credential/sops/terraform.tfstate
```

```bash
aws --profile miyabiii0310 \
  s3 ls s3://dev-react-vite-sample-tfstate/credential/sops/ --recursive
```

```bash
$ make plan
aws_kms_key.this: Refreshing state... [id=345d5aee-c404-43cd-b700-da9d01258d9f]
aws_kms_alias.this: Refreshing state... [id=alias/react-vite-sample/dev/sops]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

